### PR TITLE
fix(deploy): drop invalid GRANT CONNECT current_database()

### DIFF
--- a/infrastructure/mcp-readonly.sql
+++ b/infrastructure/mcp-readonly.sql
@@ -17,7 +17,6 @@ BEGIN
 END
 $$;
 
-GRANT CONNECT ON DATABASE current_database() TO mcp_readonly;
 GRANT USAGE ON SCHEMA public TO mcp_readonly;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO mcp_readonly;
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO mcp_readonly;


### PR DESCRIPTION
## Summary

The deploy log emits an SQL error every push:

```
ERROR:  syntax error at or near "("
LINE 1: GRANT CONNECT ON DATABASE current_database() TO mcp_readonly...
                           ^
```

`current_database()` is a function call; `GRANT CONNECT ON DATABASE <name>` needs a literal identifier. Since psql in the deploy step runs without `ON_ERROR_STOP=1` the deploy continued and the workflow stayed green, but the noise has been there on every push.

The grant is also redundant: every role inherits `CONNECT` on every database via the implicit `PUBLIC` grant unless someone explicitly `REVOKE`s it (nothing in this repo does). The initdb-time twin at `postgres-init/01_mcp_readonly.sql` doesn't grant CONNECT either, so dropping the line keeps the two files in sync.

## Test plan

- [x] Inspected both `mcp-readonly.sql` files — schema-level grants identical now
- [ ] Next deploy log no longer shows the `syntax error at or near "("` block
- [ ] IMSLP search still works on the live site (proves `mcp_readonly` can still connect — i.e. PUBLIC's CONNECT was sufficient)

---
_Generated by [Claude Code](https://claude.ai/code/session_01URCifQR9gtXgvzsT7uD37n)_