### PR TITLE
hooks: stop logging 4xx errors from scanner probes

### DIFF
--- a/frontend-svelte/ui/src/hooks.server.ts
+++ b/frontend-svelte/ui/src/hooks.server.ts
@@ -29,4 +29,13 @@ const handleParaglide: Handle = ({ event, resolve }) =>
 
 export const handle: Handle = sequence(Sentry.sentryHandle(), handleParaglide);
 
-export const handleError: HandleServerError = Sentry.handleErrorWithSentry();
+const sentryError = Sentry.handleErrorWithSentry();
+export const handleError: HandleServerError = (input) => {
+	// 404s (and other 4xx) come almost entirely from scanner probes
+	// hitting /sitemaps.xml, /wp-admin, /.git/config, etc. Don't log or
+	// report them — SvelteKit already returns the right status code.
+	if (typeof input.status === 'number' && input.status >= 400 && input.status < 500) {
+		return;
+	}
+	return sentryError(input);
+};


### PR DESCRIPTION
## Summary

The `handleError` hook ran `Sentry.handleErrorWithSentry()` raw, which logs (and forwards to Sentry) a full stack trace for every 404 — almost all of which are scanner probes hitting paths like `/sitemaps.xml`, `/wp-***/install.php`, `/.git/config`. Visible in the deploy log's `--- frontend logs (tail 40) ---` block on every push.

Drop 4xx; still report 5xx.

Direct push to `main` was attempted per the user's instruction but rejected by branch protection (HTTP 403), hence this PR.

## Test plan

- [x] `npm run check` clean
- [x] `npm run lint` clean
- [x] `npm run test:unit` server project — 106/106
- [ ] After merge + redeploy, frontend log tail no longer shows `Error: Not found: /sitemaps.xml` stack traces
- [ ] Real 5xx (forcing an exception in a handler) still surfaces in logs/Sentry

---
_Generated by [Claude Code](https://claude.ai/code/session_01URCifQR9gtXgvzsT7uD37n)_