### PR TITLE
ci: unblock dependabot PRs (secretless docker test, hold TypeScript 7)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,13 @@ updates:
     groups:
       npm-deps:
         patterns: ["*"]
+    ignore:
+      # svelte-check 4.7.5 declares peer typescript "^5.0.0 || ^6.0.0", so a
+      # group bump that pulls TypeScript 7 makes `npm ci` fail outright with
+      # ERESOLVE — it takes the whole group down with it (see #151). Hold TS at
+      # 6.x until svelte-check widens the range, then drop this entry.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/.github/workflows/test_docker.yaml
+++ b/.github/workflows/test_docker.yaml
@@ -11,9 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
-      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
-      POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+      # Dependabot (and fork) pull requests cannot read repository secrets —
+      # dependabot has its own separate secret store — so these arrive empty and
+      # the postgres image refuses to initialise:
+      #   Error: Database is uninitialized and superuser password is not specified.
+      # That failed this job on every dependabot PR while passing on main. The
+      # job only ever needs a throwaway database, so fall back to fixed local
+      # values. docker-compose.yaml has no defaults for these three (unlike
+      # MCP_READONLY_PASSWORD, which defaults to `readonly`), which is why the
+      # fallback belongs here.
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER || 'postgres' }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD || 'postgres' }}
+      POSTGRES_DB: ${{ secrets.POSTGRES_DB || 'postgres' }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Two independent reasons dependabot PRs currently cannot reach green.

## 1. Docker Test Suite needs secrets dependabot can't read

It passes on `main` but failed on **every** dependabot PR:

```
Error: Database is uninitialized and superuser password is not specified.
dependency failed to start: container postgres_db exited (1)
```

The job feeds `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` from repository
secrets, and **dependabot PRs cannot read repository secrets** — dependabot has its
own separate store — so they arrive empty and the postgres image refuses to
initialise. The job only needs a throwaway database, so it now falls back to fixed
local values. Fork PRs have the same limitation and are fixed too.

This was the **only** failing check on:

- #120 `actions/checkout` 6 → 7
- #122 `actions/cache` 4 → 6
- #132 `actions/setup-node` 6 → 7

so those three should go green once this lands and they rebase.

## 2. #151 cannot resolve at all — TypeScript 7 vs svelte-check

```
npm error While resolving: svelte-check@4.7.5
npm error Found: typescript@7.0.2
npm error peer typescript@"^5.0.0 || ^6.0.0" from svelte-check@4.7.5
```

`npm ci` fails with ERESOLVE, so nothing in that PR can build. Since the npm group
is `patterns: ["*"]`, one incompatible package blocks five otherwise-fine updates.

This holds `typescript` at 6.x in `dependabot.yml`. **Drop that ignore entry once
svelte-check widens its peer range.** After merging, `@dependabot recreate` on #151
should give a group without TS 7 that can actually install.

Note this is not something CI configuration can paper over — it's a real upstream
peer-dependency conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)