### PR TITLE
ci(dependabot): keep majors out of the grouped PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     groups:
       python-deps:
         patterns: ["*"]
+        # Majors arrive as their own PRs. Grouped with everything else, a single
+        # breaking major blocks every safe update in the batch.
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "npm"
     directory: "/frontend-svelte/ui"
@@ -17,12 +20,22 @@ updates:
     groups:
       npm-deps:
         patterns: ["*"]
+        # Majors arrive as their own PRs — see the ignores below for why grouping
+        # them was actively harmful here.
+        update-types: ["minor", "patch"]
     ignore:
       # svelte-check 4.7.5 declares peer typescript "^5.0.0 || ^6.0.0", so a
       # group bump that pulls TypeScript 7 makes `npm ci` fail outright with
       # ERESOLVE — it takes the whole group down with it (see #151). Hold TS at
       # 6.x until svelte-check widens the range, then drop this entry.
       - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # @tanstack/table-core v9 removed the row-model factory exports
+      # (getCoreRowModel, getSortedRowModel, getFilteredRowModel,
+      # getPaginationRowModel), so upgrading fails the production build with 17
+      # MISSING_EXPORT errors. That needs a code migration — tracked in #155.
+      # Remove this entry as part of that work.
+      - dependency-name: "@tanstack/table-core"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"


### PR DESCRIPTION
Both grouped dependabot PRs raised today were unmergeable, for the same structural
reason: the group is `patterns: ["*"]` with no update-type restriction, so a single
breaking major blocks every safe update batched with it.

| PR | Blocker |
|---|---|
| #151 | `typescript@7.0.2` is outside `svelte-check@4.7.5`'s peer range `^5.0.0 \|\| ^6.0.0` → `npm ci` fails with ERESOLVE, nothing builds |
| #154 (its recreation) | `@tanstack/table-core@9.1.2` removed the row-model factory exports → production build fails with **17 MISSING_EXPORT errors** |

#154 contained **four majors and nothing else** (`@tanstack/table-core` 8→9,
`@types/node` 25→26, `prettier-plugin-svelte` 3→4, `vitest-browser-svelte` 2→3), so
there was no safe subset to salvage.

## Change

Both groups now take **minor and patch only**. Majors are still raised, but as
individual PRs that can be judged on their own — which is what a major deserves
after `pydantic-ai` 1.x → 2.x silently removed `MCPServerSSE` in this very repo.

This also makes the new auto-merge workflow useful: minor/patch groups go green and
merge themselves, while majors wait for a human.

## Two majors additionally ignored

These are known-broken, not merely risky, so an individual PR would just sit red:

- **typescript** — until `svelte-check` widens its peer range.
- **@tanstack/table-core** — needs a v9 API migration, tracked in **#155**.

Remove each ignore when its blocker clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)